### PR TITLE
sirius: re-add low-latency-record path

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -1210,6 +1210,10 @@
         <ctl name="MultiMedia2 Mixer SLIM_0_TX" value="1" />
     </path>
 
+    <path name="low-latency-record">
+        <ctl name="MultiMedia5 Mixer SLIM_0_TX" value="1" />
+    </path>
+
     <path name="voice-call">
         <ctl name="SLIM_0_RX_Voice Mixer CSVoice" value="1" />
         <ctl name="Voice_Tx Mixer SLIM_0_TX_Voice" value="1" />


### PR DESCRIPTION
Needed for video calls on skype maybe others

was removed in commit: 078351ee536babce58e858b82d5697c8d5b4a85b

E/audio_route(  342): unable to find path 'low-latency-record'

Signed-off-by: David Viteri davidteri91@gmail.com
